### PR TITLE
OneTrading Exchange changed the public/private URL

### DIFF
--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -115,8 +115,8 @@ export default class onetrading extends Exchange {
             'urls': {
                 'logo': 'https://github.com/ccxt/ccxt/assets/43336371/bdbc26fd-02f2-4ca7-9f1e-17333690bb1c',
                 'api': {
-                    'public': 'https://api.onetrading.com/public',
-                    'private': 'https://api.onetrading.com/public',
+                    'public': 'https://api.onetrading.com/fast',
+                    'private': 'https://api.onetrading.com/fast',
                 },
                 'www': 'https://onetrading.com/',
                 'doc': [


### PR DESCRIPTION
The currently set URL for instruments (https://api.onetrading.com/public/v1/instruments) does not deliver any instruments. 
The new URL (https://api.onetrading.com/fast/v1/instruments) does delivery the requested data.

See their documentation for this end-point: https://docs.onetrading.com/#rest-api-overview
It seems all URL's are changed; so the new public/private URL's will be valid.

Tested with fetchMarkets.